### PR TITLE
Fixed exception on trying to forEach empty request headers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -221,7 +221,7 @@ Formsy.Form = React.createClass({
 
     this.props.onSubmit();
 
-    var headers = (Object.keys(this.props.headers).length && this.props.headers) || options.headers;
+    var headers = (Object.keys(this.props.headers).length && this.props.headers) || options.headers || {};
 
     ajax[this.props.method || 'post'](this.props.url, this.model, this.props.contentType || options.contentType || 'json', headers)
       .then(function (response) {


### PR DESCRIPTION
When no options.headers is set and Form does not provide headers request() function in Promise tries to:

    Object.keys(headers).forEach(function (header) {

which fails with "Object.keys called on non-object"