### PR TITLE
Fixed uncaught exception on parsing non-JSON AJAX response

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -64,10 +64,15 @@ var request = function (method, url, data, contentType, headers) {
       xhr.onreadystatechange = function () {
         if (xhr.readyState === 4) {
 
-          if (xhr.status >= 200 && xhr.status < 300) {
-            resolve(xhr.responseText ? JSON.parse(xhr.responseText) : null);
-          } else {
-            reject(xhr.responseText ? JSON.parse(xhr.responseText) : null);
+          try {
+            var response = xhr.responseText ? JSON.parse(xhr.responseText) : null;
+            if (xhr.status >= 200 && xhr.status < 300) {
+              resolve(response);
+            } else {
+              reject(response);
+            }
+          } catch (e) {
+            reject(e);
           }
 
         }


### PR DESCRIPTION
When server responds with non-JSON response, onreadystatechange tries to JSON.parse() it and throws.