### PR TITLE
registerInputs: Support null/undefined children; add test

### DIFF
--- a/specs/Formsy-spec.js
+++ b/specs/Formsy-spec.js
@@ -14,6 +14,42 @@ describe('Formsy', function () {
       expect(form.getDOMNode().className).toEqual('foo');
     });
 
+    it('should allow for null/undefined children', function (done) {
+      var TestInput = React.createClass({
+        mixins: [Formsy.Mixin],
+        changeValue: function (event) {
+          this.setValue(event.target.value);
+        },
+        render: function () {
+          return <input value={this.getValue()} onChange={this.changeValue}/>
+        }
+      });
+
+      var model = null;
+      var TestForm = React.createClass({
+        onSubmit: function (formModel) {
+          model = formModel;
+        },
+        render: function () {
+          return (
+            <Formsy.Form onSubmit={ this.onSubmit }>
+              <h1>Test</h1>
+              { null }
+              { undefined }
+              <TestInput name='name' value={ 'foo' } />
+            </Formsy.Form>
+          );
+        }
+      });
+
+      var form = TestUtils.renderIntoDocument(<TestForm/>);
+      setTimeout(function () {
+        TestUtils.Simulate.submit(form.getDOMNode());
+        expect(model).toEqual({name: 'foo'});
+        done();
+      }, 10);
+    });
+
     it('should allow for inputs being added dynamically', function (done) {
 
       var inputs = [];

--- a/src/main.js
+++ b/src/main.js
@@ -351,13 +351,13 @@ Formsy.Form = React.createClass({
   registerInputs: function (children) {
     React.Children.forEach(children, function (child) {
 
-      if (child.props && child.props.name) {
+      if (child && child.props && child.props.name) {
         child.props._attachToForm = this.attachToForm;
         child.props._detachFromForm = this.detachFromForm;
         child.props._validate = this.validate;
       }
 
-      if (child.props && child.props.children) {
+      if (child && child.props && child.props.children) {
         this.registerInputs(child.props.children);
       }
 


### PR DESCRIPTION
A lot of react examples have rendering functions which early return null
(such as a closed dropdown).  This method was erroring in that case.