### PR TITLE
Actually check for invalid floats

### DIFF
--- a/specs/Validation-spec.js
+++ b/specs/Validation-spec.js
@@ -162,4 +162,32 @@ describe('Validation', function() {
 
   });
 
+  it('RULE: isNumeric is false (string representation of an invalid float)', function () {
+
+    var isValid = jasmine.createSpy('valid');
+    var TestInput = React.createClass({
+      mixins: [Formsy.Mixin],
+      updateValue: function (event) {
+        this.setValue(event.target.value);
+      },
+      render: function () {
+        if (this.isValid()) {
+          isValid();
+        }
+        return <input value={this.getValue()} onChange={this.updateValue}/>
+      }
+    });
+    var form = TestUtils.renderIntoDocument(
+      <Formsy.Form>
+        <TestInput name="foo" value="foo" validations="isNumeric"/>
+      </Formsy.Form>
+    );
+
+    var input = TestUtils.findRenderedDOMComponentWithTag(form, 'INPUT');
+    expect(isValid).not.toHaveBeenCalled();
+    TestUtils.Simulate.change(input, {target: {value: '1.'}});
+    expect(isValid).not.toHaveBeenCalled();
+
+  });
+
 });

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,12 @@ var validationRules = {
     if (typeof value === 'number') {
       return true;
     } else {
-      return value.match(/[-+]?(\d*[.])?\d+/);
+      matchResults = value.match(/[-+]?(\d*[.])?\d+/);
+      if (!! matchResults) {
+        return matchResults[0] == value;
+      } else {
+        return false;
+      }
     }
   },
   'isAlpha': function (value) {


### PR DESCRIPTION
Good morning! So I realized that my prior pull request doesn't actually check to make sure that strings like '1.' don't count as floats. 

Here's an eample of my lack of understanding about this regex/javascript's match
````
('1.').match(/[-+]?(\d*[.])?\d+/)
>> ["1", undefined]
````

So I figured we could just check if the match actually is the original string. What do you think?