### PR TITLE
validateForm: don't run if the form is unmounted

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -449,6 +449,7 @@ Formsy.Form = React.createClass({
   // Validate the form by going through all child input components
   // and check their state
   validateForm: function () {
+    if (!this.isMounted()) return;
     var allIsValid = true;
     var inputs = this.inputs;
     var inputKeys = Object.keys(inputs);


### PR DESCRIPTION
I was seeing an error where `this.setState` was being called but `this` was
not mounted.