### PR TITLE
Fix dynamically updated input values

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -173,7 +173,7 @@ Formsy.Mixin = {
     // If the input is untouched and something outside changes the value
     // update the FORM model by re-attaching to the form
     if (this.state._isPristine) {
-      if (this.props.value !== prevProps.value && this.state._value === prevProps.value) {
+      if (this.props.value !== prevProps.value) {
         this.state._value = this.props.value || '';
         this.props._attachToForm(this);
       }


### PR DESCRIPTION
This fixes a bug where if props.value is not defined state._value is an
empty string.  This is fine for the initial render.  But since we check
to see if prevProps.value === state._value (undefined === ''), we never
run the code to update the input state's value.