### PR TITLE
Check isMounted in setTimeout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -151,6 +151,7 @@ Formsy.Mixin = {
 
     if (!this.props._attachToForm) {
       return setTimeout(function () {
+        if (!this.isMounted()) return;
         if (!this.props._attachToForm) {
           throw new Error('Form Mixin requires component to be nested in a Form');
         }
@@ -271,6 +272,7 @@ Formsy.Form = React.createClass({
     // The updated children array is not available here for some reason,
     // we need to wait for next event loop
     setTimeout(function () {
+      if (!this.isMounted()) return;
       this.registerInputs(this.props.children);
 
       var newInputKeys = Object.keys(this.inputs);


### PR DESCRIPTION
This fixes some occasional errors that I would see when causing a form
to unmount.  The unmount would happen before the setTimeout which then
caused setState to be called on an unmounted component.  React throws an
error in this case.

The fix is to check if the component is mounted before running the body
of the setTimeout