### PR TITLE
Move React to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vinyl-source-stream": "^0.1.1",
     "watchify": "^2.1.1"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.12.2"
   }
 }


### PR DESCRIPTION
Using this package and `react` with `npm` causes both scripts to be loaded twice. Peer dependencies is meant to fix this.

See http://blog.nodejs.org/2013/02/07/peer-dependencies/