### PR TITLE
Add repository to package.json (prevents npm WARN)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "formsy-react",
   "version": "0.8.0",
   "description": "A form input builder and validator for React JS",
+  "repository": {
+  "type": "git",
+  "url": "https://github.com/christianalfoni/formsy-react.git"
+  }
   "main": "src/main.js",
   "scripts": {
     "test": "./node_modules/.bin/jasmine-node ./specs"


### PR DESCRIPTION
This prevents the npm warning:
``` 
npm WARN package.json formsy-react@0.8.0 No repository field.
```