### PR TITLE
Suppress error in non-browser environments

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-var csrfTokenSelector = document.querySelector('meta[name="csrf-token"]');
+var csrfTokenSelector = typeof document != 'undefined' ? document.querySelector('meta[name="csrf-token"]') : null;
 
 var toURLEncoded = function (element, key, list) {
   var list = list || [];


### PR DESCRIPTION
Hey! We’re using [ReactJS.NET](http://reactjs.net/) to render initial page state. We found that your component throws error because `document` object is missing in non-browser environment. Could you merge my pull-request and release new version, please.