### PR TITLE
Allow a component to decide whether it is valid (fixes #60)

### DIFF
--- a/specs/Validation-spec.js
+++ b/specs/Validation-spec.js
@@ -50,6 +50,37 @@ describe('Validation', function() {
 
   });
 
+  it('should use provided checkValidity function', function () {
+
+    var isValid = jasmine.createSpy('valid');
+    var TestInput = React.createClass({
+      mixins: [Formsy.Mixin],
+      updateValue: function (event) {
+        this.setValue(event.target.value);
+      },
+      render: function () {
+        if (this.isValid()) {
+          isValid();
+        }
+        return <input value={this.getValue()} onChange={this.updateValue}/>
+      },
+      checkValidity: function () {
+        return this.getValue() === "checkValidity";
+      }
+    });
+    var form = TestUtils.renderIntoDocument(
+      <Formsy.Form>
+        <TestInput name="foo" value="checkInvalidity"/>
+      </Formsy.Form>
+    );
+
+    var input = TestUtils.findRenderedDOMComponentWithTag(form, 'INPUT');
+    expect(isValid).not.toHaveBeenCalled();
+    TestUtils.Simulate.change(input, {target: {value: 'checkValidity'}});
+    expect(isValid).toHaveBeenCalled();
+
+  });
+
   it('RULE: isEmail', function () {
 
     var isValid = jasmine.createSpy('valid');

--- a/src/main.js
+++ b/src/main.js
@@ -212,7 +212,7 @@ Formsy.Form = React.createClass({
       this.props.onChange(this.getCurrentValues());
     }
 
-    if (!component.props.required && !component._validations) {
+    if (!component.props.required && !component._validations && !component.checkValidity) {
       return;
     }
 
@@ -249,6 +249,11 @@ Formsy.Form = React.createClass({
         }
       }.bind(this));
     }
+    if (typeof component.checkValidity === "function") {
+      // the component defines an explicit checkValidity function
+      isValid = component.checkValidity()
+    }
+
     return isValid;
   },
 


### PR DESCRIPTION
As in #60 explained, here is the PR to allow components to decide whether they are valid via a `checkValidity` method. I'm happy to discuss and change the PR, if you are not satisfied with the implementation.

A few notes/questions which might be a bit off-topic:
-  How is the current semantic, when multiple validation rules are provided? Are they conjunctive or disjunctive (is something valid if *all* rules are valid or if *some* rule is valid)? The readme only says "[Validations are an] comma seperated list with validation rules.". And if I see it correctly the current implementation lets the "last one win". I implemented my change in the same manner, but I'm not sure whether I missed something.
- `npm test` does not work, since it cannot handle the jsx code. I know, that the readme describes how the tests can be started, but maybe you want to find a way how `npm test` can also work, since it is pretty standard. Or simply remove it from the `package.json` :) If you get `npm test` to work you could easily integrate Travis builds.