### PR TITLE
Fixed equalsField validation rule.

### DIFF
--- a/src/validationRules.js
+++ b/src/validationRules.js
@@ -51,7 +51,7 @@ module.exports = {
     return value == eql;
   },
   equalsField: function (values, value, field) {
-    return value == this[field];
+    return value == values[field];
   },
   maxLength: function (values, value, length) {
     return value !== undefined && value.length <= length;


### PR DESCRIPTION
I tried to do a validation with `equalsField` rule and it retuns false all the time, because `this[field]` is always `undefined`. I did an adjustment and now I am using `values[field]`.