### PR TITLE
Add type check to isSame

### DIFF
--- a/specs/Utils-spec.jsx
+++ b/specs/Utils-spec.jsx
@@ -11,9 +11,21 @@ describe('Utils', function() {
     var objD = [{
       foo: ['bar']
     }];
+	var objE, objF;
+	var objG = null;
+	var objH = null;
+
     expect(utils.isSame(objA, objB)).toBe(true);
     expect(utils.isSame(objC, objD)).toBe(true);
     expect(utils.isSame(objA, objD)).toBe(false);
+
+    expect(utils.isSame(objE, objF)).toBe(true);
+    expect(utils.isSame(objA, objF)).toBe(false);
+    expect(utils.isSame(objE, objA)).toBe(false);
+
+    expect(utils.isSame(objG, objH)).toBe(true);
+    expect(utils.isSame(objA, objH)).toBe(false);
+    expect(utils.isSame(objG, objA)).toBe(false);
   });
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ module.exports = {
       return false;
     } else if (Array.isArray(a)) {
       return !this.arraysDiffer(a, b);
-    } else if (typeof a === 'object' && a !== null) {
+    } else if (typeof a === 'object' && a !== null && b !== null) {
       return !this.objectsDiffer(a, b);
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,7 @@ module.exports = {
 
     if (Array.isArray(a)) {
       return !this.arraysDiffer(a, b);
-    } else if (typeof a === 'object' && a !== null) {
+    } else if (typeof a === 'object' && a !== null && a !== undefined) {
       return !this.objectsDiffer(a, b);
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,9 +27,11 @@ module.exports = {
   },
   isSame: function (a, b) {
 
-    if (Array.isArray(a)) {
+    if (typeof a !== typeof b) {
+      return false;
+    } else if (Array.isArray(a)) {
       return !this.arraysDiffer(a, b);
-    } else if (typeof a === 'object' && a !== null && a !== undefined) {
+    } else if (typeof a === 'object' && a !== null) {
       return !this.objectsDiffer(a, b);
     }
 


### PR DESCRIPTION
In utils.js, the isSame function can run into some issues if `a` and `b` are not of the same type. Specifically, if `a` is an array or object but `b` is null or undefined, and exception is thrown in utils.js line 17 `TypeError: Cannot convert undefined or null to object`. This is thrown when calling `Object.keys()` on an undefined or null variable.

My pull request just checks to make sure `typeof a === typeof b` before making decisions based on the type of `a`. If variables are of different types, isSame now properly returns false.