### PR TITLE
Relax react peerDependency to minor level (0.13.x instead of ^0.13.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "webpack-dev-server": "^1.7.0"
   },
   "peerDependencies": {
-    "react": "^0.13.1"
+    "react": "0.13.x"
   }
 }


### PR DESCRIPTION
As formsy is a library we should not force the user to a certain patch-level version of react. Anything in the `0.13.x` branch should be fine.

If there is a specific bug that requires at least `0.13.1`, feel free to change it to `>=0.13.1`