### PR TITLE
Make it browserify-friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "url": "https://github.com/christianalfoni/formsy-react.git"
   },
   "main": "src/main.js",
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  },
   "scripts": {
     "start": "webpack-dev-server --content-base build",
     "deploy": "NODE_ENV=production webpack -p --config webpack.production.config.js",


### PR DESCRIPTION
Because `main.js` uses ES2015, this tells browserify to compile it with [babelify](https://www.npmjs.com/package/babelify) first. I wish there was a way to simply override your `package.json` from my project :confused: 