### PR TITLE
Update peer dependency to allow react 0.14.0-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "webpack-dev-server": "^1.7.0"
   },
   "peerDependencies": {
-    "react": "0.13.x"
+    "react": "0.13.x || >=0.14.0-beta1"
   }
 }


### PR DESCRIPTION
Or should peer dependencies be removed altogether?