### PR TITLE
Fix 'localhost' links in 'Examples' readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,10 +23,10 @@ If it is not helped try update your node.js and npm.
 
 ## Examples
 
-1. [**Login**](http://localhost:8080/login)
+1. [**Login**](login)
 
     Two required fields with simple validation.
 
-2. [**Custom Validation**](http://localhost:8080/custom-validation)
+2. [**Custom Validation**](custom-validation)
 
-    One field with added validation rule (`Formsy.addValidationRule`) and one field with dynamically added validation and error messages. 
+    One field with added validation rule (`Formsy.addValidationRule`) and one field with dynamically added validation and error messages.


### PR DESCRIPTION
While clicking around the project I noticed that two links in the README for the examples directory are hardcoded to `http://localhost:8080`. These links do not take the user to the expected destination in the GitHub source tree.

GitHub [promotes the use of relative paths](https://help.github.com/articles/relative-links-in-readmes/) for all markdown links so that users who clone or fork repositories can still use these links.

This PR replaces the README's localhost links with relative paths.

