### PR TITLE
fix links so they work on githib

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,10 +23,10 @@ If it is not helped try update your node.js and npm.
 
 ## Examples
 
-1. [**Login**](http://localhost:8080/login)
+1. [**Login**](login)
 
     Two required fields with simple validation.
 
-2. [**Custom Validation**](http://localhost:8080/custom-validation)
+2. [**Custom Validation**](custom-validation)
 
     One field with added validation rule (`Formsy.addValidationRule`) and one field with dynamically added validation and error messages. 


### PR DESCRIPTION
Before the links to the examples pointed towards `localhost:8080`; therefore not easily—well, it wasn't exactly hard to find either—accessible from the github repository. 'Tis but a simple fix, will probably save somebody else a few seconds. Great repo btw.