### PR TITLE
Add getInitialState to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Complete API reference is available [here](/API.md).
   /** @jsx React.DOM */
   var Formsy = require('formsy-react');
   var MyAppForm = React.createClass({
+    getInitialState: function () {
+      return {
+        canSubmit: false
+      }
+    },
     enableButton: function () {
       this.setState({
         canSubmit: true


### PR DESCRIPTION
The main example in the README doesn't work, as it has no initial state for `canSubmit`.

This PR simply adds a `getInitialState` method returning `canSubmit: false`, as it may help newcomers have a working prototype just by copying the readme example.