### PR TITLE
Transpile with Babel prior to publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 build
 node_modules
+lib

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "type": "git",
     "url": "https://github.com/christianalfoni/formsy-react.git"
   },
-  "main": "src/main.js",
+  "main": "lib/main.js",
   "scripts": {
     "start": "webpack-dev-server --content-base build",
     "deploy": "NODE_ENV=production webpack -p --config webpack.production.config.js",
     "test": "node testrunner",
-    "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples"
+    "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples",
+    "prepublish": "babel ./src/ -d ./lib/"
   },
   "author": "Christian Alfoni",
   "license": "MIT",


### PR DESCRIPTION
This enables Node environments to use `require('formsy-react')` instead of
having to transpile it themselves

Fixes #220

Should not really have any affect on callers - transpiled code is functionally equivalent
