### PR TITLE
Allow formsy to be shared with parent through context

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,9 @@ Formsy.Form = React.createClass({
       preventExternalInvalidation: false
     };
   },
-
+	contextTypes: {
+		shareFormsyWithParent: React.PropTypes.func
+	},
   childContextTypes: {
     formsy: React.PropTypes.object
   },
@@ -67,6 +69,7 @@ Formsy.Form = React.createClass({
   componentWillMount: function () {
     this.inputs = {};
     this.model = {};
+		if(this.context.shareFormsyWithParent) this.context.shareFormsyWithParent(this);
   },
 
   componentDidMount: function () {

--- a/tests/Formsy-spec.js
+++ b/tests/Formsy-spec.js
@@ -701,6 +701,42 @@ export default {
 
     }
 
-  }
+  },
+  
+	'should share formsy with parent through context': function (test) {
+		const TestForm = React.createClass({
+			render() {
+				return (
+					<Formsy.Form>
+						<TestInput name="foo" value="foo" type="checkbox" />
+						<button type="submit">Save</button>
+					</Formsy.Form>
+				);
+			}
+		});
 
+		var formWasShared = false;
+
+		const Wrapper = React.createClass({
+			getChildContext: function() {
+				var self = this;
+				return {  
+					shareFormsyWithParent: function(form){
+						formWasShared = true;
+					}
+				};
+			},
+			childContextTypes: {
+				shareFormsyWithParent: React.PropTypes.func
+			},
+			render(){
+				return <TestForm />
+			}
+		});
+
+		const form = TestUtils.renderIntoDocument(<Wrapper />);
+
+		test.equal(formWasShared, true);
+		test.done();
+	}
 };


### PR DESCRIPTION
Hi,

I'm fairly new to React, so I'm not sure if this is the right way to do this or not, but I wanted to be able to share Formsy instances with components that wrap it so I can have multiple levels of abstraction. IE, something like this:

Level 1: AppForm

Level2: FormWrapper

Level3: Formsy

The reason I want to be able to reference formsy in components that wrap it is so I can do things like this:

```
{this.form.inputs.HasDependencies.hasValue() ? <Input label="Dependency!" type="text" name="dependentOnHasDependencies" /> : ''}
```

If there is an easier way to do this I would love to know = ) Thanks for your great work on this! I was writing my own and after reading the source code for Formsy decided it was a better option.