### PR TITLE
Prevent multiple rendering with PureRenderMixin

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ var Mixin = require('./Mixin.js');
 var HOC = require('./HOC.js');
 var Decorator = require('./Decorator.js');
 var options = {};
+var emptyArray = [];
 
 Formsy.Mixin = Mixin;
 Formsy.HOC = HOC;
@@ -277,7 +278,7 @@ Formsy.Form = React.createClass({
       error: (function () {
 
         if (isValid && !isRequired) {
-          return [];
+          return emptyArray;
         }
 
         if (validationResults.errors.length) {


### PR DESCRIPTION
Creating a new instance of error triggers two additional rendering when typing in an input, using same instance prevent it to happen.