### PR TITLE
Expose setState through HOC and Decorator interfaces

### DIFF
--- a/src/Decorator.js
+++ b/src/Decorator.js
@@ -6,6 +6,7 @@ module.exports = function () {
       mixins: [Mixin],
       render: function () {
         return React.createElement(Component, {
+          setState: this.setState.bind(this),
           setValidations: this.setValidations,
           setValue: this.setValue,
           resetValue: this.resetValue,

--- a/src/HOC.js
+++ b/src/HOC.js
@@ -5,6 +5,7 @@ module.exports = function (Component) {
     mixins: [Mixin],
     render: function () {
       return React.createElement(Component, {
+        setState: this.setState.bind(this),
         setValidations: this.setValidations,
         setValue: this.setValue,
         resetValue: this.resetValue,


### PR DESCRIPTION
To implement this: #180 using HOC or Decorator interfaces, this.setState needs to be exposed through props and bound to the internal method.

This PR address the issue.
