### PR TITLE
Add a callback as paramteter to setValue function

### DIFF
--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -115,13 +115,17 @@ module.exports = {
   },
 
   // We validate after the value has been set
-  setValue: function (value) {
+  setValue: function (value, callback) {
     this.setState({
       _value: value,
       _isPristine: false
     }, function () {
       this.context.formsy.validate(this);
       //this.props._validate(this);
+
+      if (callback) {
+        callback();
+      }
     }.bind(this));
   },
   resetValue: function () {


### PR DESCRIPTION
Provides an optional callback parameter to `setValue` allowing function calls depending on the updated value after calling `setValue`.

Without callback a call to `getModel()` of the parent form component after setting the value to a custom input component returns the previous value for this input.

Solving [#344](https://github.com/christianalfoni/formsy-react/issues/344).