### PR TITLE
Use better displayNames for components wrapped into HOC

### DIFF
--- a/src/HOC.js
+++ b/src/HOC.js
@@ -2,6 +2,7 @@ var React = global.React || require('react');
 var Mixin = require('./Mixin.js');
 module.exports = function (Component) {
   return React.createClass({
+    displayName: 'Formsy(' + getDisplayName(Component) + ')',
     mixins: [Mixin],
     render: function () {
       return React.createElement(Component, {
@@ -25,3 +26,11 @@ module.exports = function (Component) {
     }
   });
 };
+
+function getDisplayName(Component) {
+  return (
+    Component.displayName ||
+    Component.name ||
+    (typeof Component === 'string' ? Component : 'Component')
+  );
+}


### PR DESCRIPTION
Currently, the `displayName` of the component wrapped into HOC looks like `Constructor`, which isn't very descriptive.

<img width="530" alt="screenshot 2016-06-11 13 23 54" src="https://cloud.githubusercontent.com/assets/1524432/15984792/cefb623e-2fd7-11e6-85f7-eb357cdc2a0e.png">

This PR introduces a better `displayName` for such components: `Formsy(ComponentName)`

<img width="659" alt="screenshot 2016-06-11 13 10 23" src="https://cloud.githubusercontent.com/assets/1524432/15984798/e9ebddee-2fd7-11e6-8c6f-1484bfedb01e.png">
