### PR TITLE
Possible typo?

### DIFF
--- a/API.md
+++ b/API.md
@@ -373,7 +373,7 @@ var MyInput = React.createClass({
       <div>
         <span>{face}</span>
         <input type="text" onChange={this.changeValue} value={this.getValue()}/>
-        <span>{this.getErrorMessage()}</span>
+        <span>{this.getErrorMessages()}</span>
       </div>
     );
   }


### PR DESCRIPTION
The heading points to the documentation for `#getErrorMessages` but the examples shows a `#getErrorMessage` example.