### PR TITLE
Add getInputIndex method

### DIFF
--- a/src/Decorator.js
+++ b/src/Decorator.js
@@ -13,6 +13,7 @@ module.exports = function () {
           hasValue: this.hasValue,
           getErrorMessage: this.getErrorMessage,
           getErrorMessages: this.getErrorMessages,
+          getInputIndex: this.getInputIndex,
           isFormDisabled: this.isFormDisabled,
           isValid: this.isValid,
           isPristine: this.isPristine,

--- a/src/HOC.js
+++ b/src/HOC.js
@@ -13,6 +13,7 @@ module.exports = function (Component) {
         hasValue: this.hasValue,
         getErrorMessage: this.getErrorMessage,
         getErrorMessages: this.getErrorMessages,
+        getInputIndex: this.getInputIndex,
         isFormDisabled: this.isFormDisabled,
         isValid: this.isValid,
         isPristine: this.isPristine,

--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -171,5 +171,8 @@ module.exports = {
   isValidValue: function (value) {
     return this.context.formsy.isValidValue.call(null, this, value);
     //return this.props._isValidValue.call(null, this, value);
+  },
+  getInputIndex: function () {
+    return this.context.formsy.getInputIndex(this);
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,7 @@ Formsy.Form = React.createClass({
       formsy: {
         attachToForm: this.attachToForm,
         detachFromForm: this.detachFromForm,
+        getInputIndex: this.getInputIndex,
         validate: this.validate,
         isFormDisabled: this.isFormDisabled,
         isValidValue: (component, value) => {
@@ -422,6 +423,11 @@ Formsy.Form = React.createClass({
 
     this.validateForm();
   },
+
+  getInputIndex: function (component) {
+    return this.inputs.indexOf(component);
+  },
+
   render: function () {
     var {
       mapping,


### PR DESCRIPTION
This gives a `formsy-react` component the ability to get the index in which it is
registered within the form. This index is unique to that component, and is
useful for use in generating `id` attributes for elements within the component.