### PR TITLE
Add default of empty string for value

### DIFF
--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -33,7 +33,7 @@ var convertValidationsToObject = function (validations) {
 module.exports = {
   getInitialState: function () {
     return {
-      _value: this.props.value,
+      _value: this.props.value || '',
       _isRequired: false,
       _isValid: true,
       _isPristine: true,


### PR DESCRIPTION
Add default value of '' fixes `reset()` working without passing object 

Fixes: https://github.com/christianalfoni/formsy-react/issues/332