### PR TITLE
Fixed resetModel method with nested data

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -139,6 +139,7 @@ Formsy.Form = React.createClass({
 
   // Reset each key in the model to the original / initial / specified value
   resetModel: function (data) {
+    data = formDataToObject.fromObj(data);
     this.inputs.forEach(component => {
       var name = component.props.name;
       if (data && data.hasOwnProperty(name)) {


### PR DESCRIPTION
This is my first time using Formsy and I had this issue.
Reseting the form was not working with nested data.
A one liner fix thanks to the great `form-data-to-object` library.

Thanks for this great repo :-)