### PR TITLE
Type casts var regexp to RegExp so .test() can always be called

### DIFF
--- a/src/validationRules.js
+++ b/src/validationRules.js
@@ -14,7 +14,7 @@ var validations = {
     return isExisty(value);
   },
   matchRegexp: function (values, value, regexp) {
-    return !isExisty(value) || isEmpty(value) || regexp.test(value);
+    return !isExisty(value) || isEmpty(value) || (new RegExp(regexp)).test(value);
   },
   isUndefined: function (values, value) {
     return value === undefined;


### PR DESCRIPTION
closes #427