### PR TITLE
Fix deprecation warnings found in React 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "nodeunit": "^0.9.1",
     "react": "^15.5.4",
     "react-addons-pure-render-mixin": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.5.4",
     "sinon": "^1.17.3",
     "webpack": "^1.12.14",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "react-component"
   ],
   "dependencies": {
-    "form-data-to-object": "^0.2.0"
+    "create-react-class": "^15.5.2",
+    "form-data-to-object": "^0.2.0",
+    "prop-types": "^15.5.7"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -33,15 +35,15 @@
     "babel-preset-stage-2": "^6.5.0",
     "jsdom": "^6.5.1",
     "nodeunit": "^0.9.1",
-    "react": "^15.0.0",
+    "react": "^15.5.4",
     "react-addons-pure-render-mixin": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react-dom": "^15.5.4",
     "sinon": "^1.17.3",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.5.0"
   }
 }

--- a/src/Decorator.js
+++ b/src/Decorator.js
@@ -1,8 +1,9 @@
 var React = global.React || require('react');
+var createReactClass = require('create-react-class');
 var Mixin = require('./Mixin.js');
 module.exports = function () {
   return function (Component) {
-    return React.createClass({
+    return createReactClass({
       mixins: [Mixin],
       render: function () {
         return React.createElement(Component, {

--- a/src/HOC.js
+++ b/src/HOC.js
@@ -1,7 +1,8 @@
 var React = global.React || require('react');
+var createReactClass = require('create-react-class');
 var Mixin = require('./Mixin.js');
 module.exports = function (Component) {
-  return React.createClass({
+  return createReactClass({
     displayName: 'Formsy(' + getDisplayName(Component) + ')',
     mixins: [Mixin],
 

--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -1,5 +1,6 @@
 var utils = require('./utils.js');
 var React = global.React || require('react');
+var PropTypes = require('prop-types');
 
 var convertValidationsToObject = function (validations) {
 
@@ -44,7 +45,7 @@ module.exports = {
     };
   },
   contextTypes: {
-    formsy: React.PropTypes.object // What about required?
+    formsy: PropTypes.object // What about required?
   },
   getDefaultProps: function () {
     return {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,6 @@
 var React = global.React || require('react');
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var Formsy = {};
 var validationRules = require('./validationRules.js');
 var formDataToObject = require('form-data-to-object');
@@ -21,7 +23,7 @@ Formsy.addValidationRule = function (name, func) {
   validationRules[name] = func;
 };
 
-Formsy.Form = React.createClass({
+Formsy.Form = createReactClass({
   displayName: 'Formsy',
   getInitialState: function () {
     return {
@@ -46,7 +48,7 @@ Formsy.Form = React.createClass({
   },
 
   childContextTypes: {
-    formsy: React.PropTypes.object
+    formsy: PropTypes.object
   },
   getChildContext: function () {
     return {

--- a/tests/Element-spec.js
+++ b/tests/Element-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import sinon from 'sinon';
 
@@ -165,7 +166,7 @@ export default {
 
   'should allow an undefined value to be updated to a value': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       getInitialState() {
         return {value: undefined};
       },
@@ -195,7 +196,7 @@ export default {
 
   'should be able to test a values validity': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>
@@ -215,7 +216,7 @@ export default {
 
   'should be able to use an object as validations property': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>
@@ -238,7 +239,7 @@ export default {
 
   'should be able to pass complex values to a validation rule': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>
@@ -263,7 +264,7 @@ export default {
 
   'should be able to run a function to validate': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       customValidationA(values, value) {
         return value === 'foo';
       },
@@ -299,7 +300,7 @@ export default {
 
   'should not override error messages with error messages passed by form if passed eror messages is an empty object': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form validationErrors={{}}>
@@ -322,7 +323,7 @@ export default {
 
   'should override all error messages with error messages passed by form': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form validationErrors={{A: 'bar'}}>
@@ -344,7 +345,7 @@ export default {
 
   'should override validation rules with required rules': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>
@@ -374,7 +375,7 @@ export default {
 
   'should fall back to default error message when non exist in validationErrors map': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>
@@ -401,7 +402,7 @@ export default {
 
   'should not be valid if it is required and required rule is true': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>
@@ -423,7 +424,7 @@ export default {
 
   'should handle objects and arrays as values': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       getInitialState() {
         return {
           foo: {foo: 'bar'},
@@ -456,7 +457,7 @@ export default {
 
   'should handle isFormDisabled with dynamic inputs': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       getInitialState() {
         return {
           bool: true
@@ -491,7 +492,7 @@ export default {
 
   'should allow for dot notation in name which maps to a deep object': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       onSubmit(model) {
         test.deepEqual(model, {foo: {bar: 'foo', test: 'test'}});
       },
@@ -517,7 +518,7 @@ export default {
 
   'should allow for application/x-www-form-urlencoded syntax and convert to object': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       onSubmit(model) {
         test.deepEqual(model, {foo: ['foo', 'bar']});
       },

--- a/tests/Formsy-spec.js
+++ b/tests/Formsy-spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import TestInput from './utils/TestInput';
@@ -12,7 +13,7 @@ export default {
 
   'Setting up a form': {
     'should expose the users DOM node through an innerRef prop': function (test) {
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         render() {
           return (
             <Formsy.Form>
@@ -50,7 +51,7 @@ export default {
     'should allow for null/undefined children': function (test) {
 
       let model = null;
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         render() {
           return (
             <Formsy.Form onSubmit={(formModel) => (model = formModel)}>
@@ -77,7 +78,7 @@ export default {
       const inputs = [];
       let forceUpdate = null;
       let model = null;
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         componentWillMount() {
           forceUpdate = this.forceUpdate.bind(this);
         },
@@ -113,7 +114,7 @@ export default {
       const inputs = [];
       let forceUpdate = null;
       let model = null;
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         componentWillMount() {
           forceUpdate = this.forceUpdate.bind(this);
         },
@@ -151,7 +152,7 @@ export default {
       let forceUpdate = null;
       let model = null;
 
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         componentWillMount() {
           forceUpdate = this.forceUpdate.bind(this);
         },
@@ -357,7 +358,7 @@ export default {
 
 
     const hasChanged = sinon.spy();
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return <Formsy.Form onChange={hasChanged}></Formsy.Form>;
       }
@@ -385,7 +386,7 @@ export default {
   'should trigger onChange once when new input is added to form': function (test) {
 
     const hasChanged = sinon.spy();
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       getInitialState() {
         return {
           showInput: false
@@ -422,7 +423,7 @@ export default {
 
     'should allow elements to check if the form is disabled': function (test) {
 
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         getInitialState() { return { disabled: true }; },
         enableForm() { this.setState({ disabled: false }); },
         render() {
@@ -447,7 +448,7 @@ export default {
 
     'should be possible to pass error state of elements by changing an errors attribute': function (test) {
 
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         getInitialState() { return { validationErrors: { foo: 'bar' } }; },
         onChange(values) {
             this.setState(values.foo ? { validationErrors: {} } : { validationErrors: {foo: 'bar'} });
@@ -479,7 +480,7 @@ export default {
     'should trigger an onValidSubmit when submitting a valid form': function (test) {
 
       let isCalled = sinon.spy();
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         render() {
           return (
             <Formsy.Form onValidSubmit={isCalled}>
@@ -498,7 +499,7 @@ export default {
     'should trigger an onInvalidSubmit when submitting an invalid form': function (test) {
 
       let isCalled = sinon.spy();
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         render() {
           return (
             <Formsy.Form onInvalidSubmit={isCalled}>
@@ -523,7 +524,7 @@ export default {
     'should call onSubmit correctly': function (test) {
 
       const onSubmit = sinon.spy();
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         render() {
           return (
             <Formsy.Form onSubmit={onSubmit}>
@@ -544,7 +545,7 @@ export default {
     'should allow dynamic changes to false': function (test) {
 
       const onSubmit = sinon.spy();
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         getInitialState() {
           return {
             value: true
@@ -575,7 +576,7 @@ export default {
 
     'should say the form is submitted': function (test) {
 
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         render() {
           return (
             <Formsy.Form>
@@ -596,7 +597,7 @@ export default {
 
     'should be able to reset the form to its pristine state': function (test) {
 
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         getInitialState() {
           return {
             value: true
@@ -631,7 +632,7 @@ export default {
 
     'should be able to reset the form using custom data': function (test) {
 
-      const TestForm = React.createClass({
+      const TestForm = createReactClass({
         getInitialState() {
           return {
             value: true
@@ -670,7 +671,7 @@ export default {
 
   'should be able to reset the form to empty values': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form>

--- a/tests/Rules-equals-spec.js
+++ b/tests/Rules-equals-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 import immediate from './utils/immediate';
 
 import Formsy from './..';
@@ -11,7 +12,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isAlpha-spec.js
+++ b/tests/Rules-isAlpha-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isAlphanumeric-spec.js
+++ b/tests/Rules-isAlphanumeric-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isEmail-spec.js
+++ b/tests/Rules-isEmail-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isEmptyString-spec.js
+++ b/tests/Rules-isEmptyString-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isExisty-spec.js
+++ b/tests/Rules-isExisty-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isFloat-spec.js
+++ b/tests/Rules-isFloat-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isInt-spec.js
+++ b/tests/Rules-isInt-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isLength-spec.js
+++ b/tests/Rules-isLength-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isNumeric-spec.js
+++ b/tests/Rules-isNumeric-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isUrl-spec.js
+++ b/tests/Rules-isUrl-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-isWords-spec.js
+++ b/tests/Rules-isWords-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-maxLength-spec.js
+++ b/tests/Rules-maxLength-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Rules-minLength-spec.js
+++ b/tests/Rules-minLength-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import { InputFactory } from './utils/TestInput';
@@ -10,7 +11,7 @@ const TestInput = InputFactory({
   }
 });
 
-const TestForm = React.createClass({
+const TestForm = createReactClass({
   render() {
     return (
       <Formsy.Form>

--- a/tests/Validation-spec.js
+++ b/tests/Validation-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import createReactClass from 'create-react-class';
+import TestUtils from 'react-dom/test-utils';
 
 import Formsy from './..';
 import TestInput, {InputFactory} from './utils/TestInput';
@@ -112,7 +113,7 @@ export default {
 
   'should provide invalidate callback on onValiSubmit': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form onValidSubmit={(model, reset, invalidate) => invalidate({ foo: 'bar' })}>
@@ -134,7 +135,7 @@ export default {
 
   'should provide invalidate callback on onInvalidSubmit': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form onInvalidSubmit={(model, reset, invalidate) => invalidate({ foo: 'bar' })}>
@@ -156,7 +157,7 @@ export default {
 
   'should not invalidate inputs on external errors with preventExternalInvalidation prop': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form
@@ -179,7 +180,7 @@ export default {
 
   'should invalidate inputs on external errors without preventExternalInvalidation prop': function (test) {
 
-    const TestForm = React.createClass({
+    const TestForm = createReactClass({
       render() {
         return (
           <Formsy.Form onSubmit={(model, reset, invalidate) => invalidate({ foo: 'bar' })}>


### PR DESCRIPTION
Fixes #437 and #438 with minimal disruption by using the new `create-react-class`, `prop-types` packages extracted from React, and the updated `react` and `react-dom` packages for the rest.