### PR TITLE
Added possibility to use browser builtin submit

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -41,6 +41,7 @@ Formsy.Form = React.createClass({
       onInvalid: function () {},
       onChange: function () {},
       validationErrors: null,
+      preventExternalSubmit: true,
       preventExternalInvalidation: false
     };
   },
@@ -100,7 +101,7 @@ Formsy.Form = React.createClass({
   // Update model, submit to url prop and send the model
   submit: function (event) {
 
-    event && event.preventDefault();
+    this.props.preventExternalSubmit && event && event.preventDefault();
 
     // Trigger form as not pristine.
     // If any inputs have not been touched yet this will make them dirty
@@ -434,6 +435,7 @@ Formsy.Form = React.createClass({
       onChange,
       reset,
       preventExternalInvalidation,
+      preventExternalSubmit,
       onSuccess,
       onError,
       ...nonFormsyProps


### PR DESCRIPTION
When app need to issue full HTTP POST by browser means (and render resulting HTML), original Formsy was not flexible enough. This PR adds support for using the browser builtin.