### PR TITLE
Throw an error on duplicate validation rule name

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,9 @@ Formsy.defaults = function (passedOptions) {
 };
 
 Formsy.addValidationRule = function (name, func) {
+  if (Object.keys(validationRules).indexOf(name) !== -1) {
+    throw new Error('A Validation Rule with that name already exists: ' + name);
+  }
   validationRules[name] = func;
 };
 

--- a/tests/Formsy-spec.js
+++ b/tests/Formsy-spec.js
@@ -247,6 +247,15 @@ export default {
 
     },
 
+    'should not allow a custom validation to be overwritten': function (test) {
+
+      test.doesNotThrow(() => {Formsy.addValidationRule('ruleC')}, Error);
+      test.throws(() => {Formsy.addValidationRule('ruleC')}, Error);
+
+      test.done();
+
+    },
+
     'should invalidate a form if dynamically inserted input is invalid': function (test) {
 
       const isInValidSpy = sinon.spy();
@@ -332,21 +341,21 @@ export default {
 
     'runs multiple validations': function (test) {
 
-      const ruleA = sinon.spy();
-      const ruleB = sinon.spy();
-      Formsy.addValidationRule('ruleA', ruleA);
-      Formsy.addValidationRule('ruleB', ruleB);
+      const ruleD = sinon.spy();
+      const ruleE = sinon.spy();
+      Formsy.addValidationRule('ruleD', ruleD);
+      Formsy.addValidationRule('ruleE', ruleE);
 
       const form = TestUtils.renderIntoDocument(
         <Formsy.Form>
-          <TestInput name="one" validations="ruleA,ruleB" value="foo" />
+          <TestInput name="one" validations="ruleD,ruleE" value="foo" />
         </Formsy.Form>
       );
 
       const input = TestUtils.findRenderedDOMComponentWithTag(form, 'input');
       TestUtils.Simulate.change(ReactDOM.findDOMNode(input), {target: {value: 'bar'}});
-      test.equal(ruleA.calledWith({one: 'bar'}, 'bar', true), true);
-      test.equal(ruleB.calledWith({one: 'bar'}, 'bar', true), true);
+      test.equal(ruleD.calledWith({one: 'bar'}, 'bar', true), true);
+      test.equal(ruleE.calledWith({one: 'bar'}, 'bar', true), true);
       test.done();
 
     }


### PR DESCRIPTION
Currently if you add a validation rule with a name that already exists, the existing validation rule will get overwritten.  This can cause unexpected behavior because the implementation of a validation rule can be easily overwritten (especially on large projects with multiple people working on them).

This fix will check if the name of the validation rule already exists and if it does an Error is thrown.