### PR TITLE
Update to use "prop-type" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-component"
   ],
   "dependencies": {
-    "form-data-to-object": "^0.2.0"
+    "form-data-to-object": "^0.2.0",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -1,5 +1,6 @@
 var utils = require('./utils.js');
 var React = global.React || require('react');
+var PropTypes = require('prop-types');
 
 var convertValidationsToObject = function (validations) {
 
@@ -44,7 +45,7 @@ module.exports = {
     };
   },
   contextTypes: {
-    formsy: React.PropTypes.object // What about required?
+    formsy: PropTypes.object // What about required?
   },
   getDefaultProps: function () {
     return {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 var React = global.React || require('react');
+var PropTypes = require('prop-types');
 var Formsy = {};
 var validationRules = require('./validationRules.js');
 var formDataToObject = require('form-data-to-object');
@@ -46,7 +47,7 @@ Formsy.Form = React.createClass({
   },
 
   childContextTypes: {
-    formsy: React.PropTypes.object
+    formsy: PropTypes.object
   },
   getChildContext: function () {
     return {


### PR DESCRIPTION
**Description**

In the console there was an annoying warning from React:

>  "Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead."

This PR adds the prop-types dependency to the project, and updates the references.
https://github.com/facebook/prop-types

**Changes**

Files changed

- Mixin.js (updating references)
- main.js (updating references)

**Tests/Examples**

Tests are passing, examples run fine