### PR TITLE
Fix infinity rerender with NaN value

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,7 +36,9 @@ module.exports = {
       return a.toString() === b.toString();
     } else if (typeof a === 'object' && a !== null && b !== null) {
       return !this.objectsDiffer(a, b);
-    }
+    } else if (typeof a === 'number' && isNaN(a) && isNaN(b)) {
+      return true;
+    } 
 
     return a === b;
   },

--- a/tests/Utils-spec.js
+++ b/tests/Utils-spec.js
@@ -12,6 +12,8 @@ export default {
     const objF = undefined;
     const objG = null;
     const objH = null;
+    const objI = NaN;
+    const objJ = NaN;
 
     test.equal(utils.isSame(objA, objB), true);
     test.equal(utils.isSame(objC, objD), true);
@@ -25,6 +27,11 @@ export default {
     test.equal(utils.isSame(objA, objH), false);
     test.equal(utils.isSame(objC, objH), false);
     test.equal(utils.isSame(objG, objA), false);
+
+    test.equal(utils.isSame(objI, objJ), true);
+    test.equal(utils.isSame(objA, objJ), false);
+    test.equal(utils.isSame(objC, objJ), false);
+    test.equal(utils.isSame(objI, objA), false);
 
     test.equal(utils.isSame(() => {}, () => {}), true);
     test.equal(utils.isSame(objA, () => {}), false);


### PR DESCRIPTION
Using `value={NaN}` causes infinity rerender, because of  `isSame(NaN, NaN)` returns `false` due to `NaN === NaN` is `false` (https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/NaN). 

This PR fixes isSame function for this case. Test cases are added.