### PR TITLE
Don't bundle create-react-class & allow Formsy to be used globally.

### DIFF
--- a/src/Decorator.js
+++ b/src/Decorator.js
@@ -1,5 +1,5 @@
 var React = global.React || require('react');
-var createReactClass = require('create-react-class');
+var createReactClass = global.createReactClass || require('create-react-class');
 var Mixin = require('./Mixin.js');
 module.exports = function () {
   return function (Component) {

--- a/src/HOC.js
+++ b/src/HOC.js
@@ -1,5 +1,5 @@
 var React = global.React || require('react');
-var createReactClass = require('create-react-class');
+var createReactClass = global.createReactClass || require('create-react-class');
 var Mixin = require('./Mixin.js');
 module.exports = function (Component) {
   return createReactClass({

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 var PropTypes = require('prop-types');
 var React = global.React || require('react');
-var createReactClass = require('create-react-class');
+var createReactClass = global.createReactClass || require('create-react-class');
 var Formsy = {};
 var validationRules = require('./validationRules.js');
 var formDataToObject = require('form-data-to-object');

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -4,7 +4,7 @@ module.exports = {
 
   devtool: 'source-map',
   entry: path.resolve(__dirname, 'src', 'main.js'),
-  externals: 'react',
+  externals: [ 'react', 'create-react-class' ],
   output: {
     path: path.resolve(__dirname, 'release'),
     filename: 'formsy-react.js',


### PR DESCRIPTION
Hi,

When I try to load Formsy-0.19.5 with a `<script>` tag, the page dies with this error:

> create-react-class could not find the React object. If you are using script tags, make sure that React is being loaded before create-react-class.

This error happens even though React has been loaded with a `<script>` tag before loading Formsy with another `<script>` tag.  If we treat `create-react-class` as external like `react` itself, the problem disappears.  Is this acceptable?