### PR TITLE
only set form input validation errors, when an errormessage is defined

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -155,11 +155,13 @@ Formsy.Form = createReactClass({
   setInputValidationErrors: function (errors) {
     this.inputs.forEach(component => {
       var name = component.props.name;
-      var args = [{
-        _isValid: !(name in errors),
-        _validationError: typeof errors[name] === 'string' ? [errors[name]] : errors[name]
-      }];
-      component.setState.apply(component, args);
+      if (errors[name]) {
+        var args = [{
+          _isValid: !(name in errors),
+          _validationError: typeof errors[name] === 'string' ? [errors[name]] : errors[name]
+        }];
+        component.setState.apply(component, args);
+      }
     });
   },
 


### PR DESCRIPTION
Problem: when you define validationErrors on the Form Component, the validationErrors of the Child Inputs will be overwritten. With this fix only validationErrors which are defined are overwritten in den Child Inputs.

Now it is possible to combine external validated with internal validated components in one form.