### PR TITLE
Change PropType for `value` to allow array.

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -39,6 +39,7 @@ const propTypes = {
     PropTypes.string,
   ]),
   value: PropTypes.oneOfType([
+    PropTypes.array,
     PropTypes.bool,
     PropTypes.string,
   ]),

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -39,9 +39,7 @@ const propTypes = {
     PropTypes.string,
   ]),
   value: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.bool,
-    PropTypes.string,
+    PropTypes.any,
   ]),
 };
 

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -38,9 +38,7 @@ const propTypes = {
     PropTypes.object,
     PropTypes.string,
   ]),
-  value: PropTypes.oneOfType([
-    PropTypes.any,
-  ]),
+  value: PropTypes.any,
 };
 
 export {


### PR DESCRIPTION
We need to allow an array type for the value prop. For example, to set the values of multiple select component:

```jsx
const MultiSelect = (props) => {
  return (
    <select multiple value={props.value}>
       <option value="a">A</option>
       <option value="b">B</option>
       <option value="c">C</option>
    </select>
  );
}

ReactDOM.render(<MultiSelect value={['a','c']} />, mountNode);
```